### PR TITLE
implementation of the ability to change the base color

### DIFF
--- a/lib/model_viewer.dart
+++ b/lib/model_viewer.dart
@@ -11,3 +11,4 @@
 library model_viewer;
 
 export 'src/model_viewer.dart';
+export 'src/controller.dart';

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+typedef ChangeColorTypeDef = Future<String> Function(String);
+
+/// The [ModelViewerColorController] is used to control the color settings of the model viewer.
+/// If the function [changeColor(colorString)] is called, then the base color of the model will be changed.
+/// 
+/// At the moment the [ModelViewerColorController] can only change the base color of the model.
+/// The base color is auto detected by the biggest size object of the model.
+class ModelViewerColorController {
+  /// change the color by a given colorString
+  ChangeColorTypeDef changeColor;
+  // ToDo: Add a function to get possibble color areas
+  // ToDo: set colors for detected areas
+
+  void dispose() {
+    changeColor = null;
+  }
+}

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -85,8 +85,7 @@ abstract class HTMLBuilder {
     if (enableColorChange ?? false) {
       html.write(_buildColorChangeJSFunction());
     }
-
-    print(html.toString());
+    
     return html.toString();
   }
 

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -19,6 +19,7 @@ abstract class HTMLBuilder {
       final int autoRotateDelay,
       final bool autoPlay,
       final bool cameraControls,
+      final bool enableColorChange,
       final String iosSrc}) {
     final html = StringBuffer(htmlTemplate);
     html.write('<model-viewer');
@@ -64,6 +65,11 @@ abstract class HTMLBuilder {
     if (iosSrc != null) {
       html.write(' ios-src="${htmlEscape.convert(iosSrc)}"');
     }
+
+    if (enableColorChange ?? false) {
+      html.write(' id="color"');
+    }
+
     // TODO: max-camera-orbit
     // TODO: max-field-of-view
     // TODO: min-camera-orbit
@@ -75,6 +81,26 @@ abstract class HTMLBuilder {
     // TODO: shadow-intensity
     // TODO: shadow-softness
     html.writeln('></model-viewer>');
+
+    if (enableColorChange ?? false) {
+      html.write(_buildColorChangeJSFunction());
+    }
+
+    print(html.toString());
     return html.toString();
+  }
+
+  static String _buildColorChangeJSFunction() {
+    return '''
+    <script type="text/javascript">
+      function changeColor(colorString) {
+        const modelViewerColor = document.querySelector("model-viewer#color");
+        const color = colorString.split(',')
+                .map(numberString => parseFloat(numberString));
+        const [material] = modelViewerColor.model.materials;
+        material.pbrMetallicRoughness.setBaseColorFactor(color);
+      }
+    </script>
+    ''';
   }
 }

--- a/lib/src/model_viewer.dart
+++ b/lib/src/model_viewer.dart
@@ -200,7 +200,7 @@ class _ModelViewerState extends State<ModelViewer> {
   }
 
   String _buildHTML(final String htmlTemplate) {
-    var htmlBuild = HTMLBuilder.build(
+    return HTMLBuilder.build(
       htmlTemplate: htmlTemplate,
       backgroundColor: widget.backgroundColor,
       src: '/model',
@@ -215,7 +215,6 @@ class _ModelViewerState extends State<ModelViewer> {
       enableColorChange: widget.enableColorChange,
       iosSrc: widget.iosSrc,
     );
-    return htmlBuild;
   }
 
   Future<void> _initProxy() async {


### PR DESCRIPTION
I've implemented the ability to change the base color of the model. 

There is a `ModelViewerColorController` which can be used to call the JavaScript function to change the base color of the model.
Currently it only supports the auto detected base color. As I understand the documentation, the auto detection selects the largest area of the model. So if there is just a simple model, you can change the color of the whole object. Otherwise the largest object will just be changed.

Example usage:

```
// ....
ModelViewerColorController _colorController;

// ....
@override
void initState() {
    super.initState();
    _colorController = ModelViewerColorController();
}

// ....
Future void changeColor() async {
    await _colorController.changeColor("0,1,1,1");
}

// ....
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        appBar: AppBar(title: Text("Model Viewer")),
        body: ModelViewer(
          src: 'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
          enableColorChange: true,
          colorController: _colorController,
          alt: "A 3D model of an astronaut",
          ar: true,
          autoRotate: true,
          cameraControls: true,
        ),
      ),
    );
  }
}
```

