### PR TITLE
state callbacks of the modelviewer

### DIFF
--- a/lib/model_viewer.dart
+++ b/lib/model_viewer.dart
@@ -11,3 +11,4 @@
 library model_viewer;
 
 export 'src/model_viewer.dart';
+export 'src/controller.dart';

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+typedef ChangeColorTypeDef = Future<String> Function(String);
+
+/// The [ModelViewerColorController] is used to control the color settings of the model viewer.
+/// If the function [changeColor(colorString)] is called, then the base color of the model will be changed.
+/// 
+/// At the moment the [ModelViewerColorController] can only change the base color of the model.
+/// The base color is auto detected by the biggest size object of the model.
+class ModelViewerColorController {
+  /// change the color by a given colorString
+  ChangeColorTypeDef changeColor;
+  // ToDo: Add a function to get possibble color areas
+  // ToDo: set colors for detected areas
+
+  void dispose() {
+    changeColor = null;
+  }
+}

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -85,7 +85,9 @@ abstract class HTMLBuilder {
     if (enableColorChange ?? false) {
       html.write(_buildColorChangeJSFunction());
     }
-    
+
+    html.write(_buildModelVisibilityEventJSFunction());
+
     return html.toString();
   }
 
@@ -99,6 +101,17 @@ abstract class HTMLBuilder {
         const [material] = modelViewerColor.model.materials;
         material.pbrMetallicRoughness.setBaseColorFactor(color);
       }
+    </script>
+    ''';
+  }
+
+  static String _buildModelVisibilityEventJSFunction() {
+    return '''
+    <script type="text/javascript">
+        const modelViewerElement = document.querySelector("model-viewer");
+        modelViewerElement.addEventListener('model-visibility', (event) => {
+            messageIsVisibile.postMessage(event.detail.visible);
+        });
     </script>
     ''';
   }

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -85,8 +85,7 @@ abstract class HTMLBuilder {
     if (enableColorChange ?? false) {
       html.write(_buildColorChangeJSFunction());
     }
-
-    print(html.toString());
+    
     return html.toString();
   }
 

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -19,6 +19,7 @@ abstract class HTMLBuilder {
       final int autoRotateDelay,
       final bool autoPlay,
       final bool cameraControls,
+      final bool enableColorChange,
       final String iosSrc}) {
     final html = StringBuffer(htmlTemplate);
     html.write('<model-viewer');
@@ -64,6 +65,11 @@ abstract class HTMLBuilder {
     if (iosSrc != null) {
       html.write(' ios-src="${htmlEscape.convert(iosSrc)}"');
     }
+
+    if (enableColorChange ?? false) {
+      html.write(' id="color"');
+    }
+
     // TODO: max-camera-orbit
     // TODO: max-field-of-view
     // TODO: min-camera-orbit
@@ -75,6 +81,26 @@ abstract class HTMLBuilder {
     // TODO: shadow-intensity
     // TODO: shadow-softness
     html.writeln('></model-viewer>');
+
+    if (enableColorChange ?? false) {
+      html.write(_buildColorChangeJSFunction());
+    }
+
+    print(html.toString());
     return html.toString();
+  }
+
+  static String _buildColorChangeJSFunction() {
+    return '''
+    <script type="text/javascript">
+      function changeColor(colorString) {
+        const modelViewerColor = document.querySelector("model-viewer#color");
+        const color = colorString.split(',')
+                .map(numberString => parseFloat(numberString));
+        const [material] = modelViewerColor.model.materials;
+        material.pbrMetallicRoughness.setBaseColorFactor(color);
+      }
+    </script>
+    ''';
   }
 }

--- a/lib/src/model_viewer.dart
+++ b/lib/src/model_viewer.dart
@@ -200,7 +200,7 @@ class _ModelViewerState extends State<ModelViewer> {
   }
 
   String _buildHTML(final String htmlTemplate) {
-    var htmlBuild = HTMLBuilder.build(
+    return HTMLBuilder.build(
       htmlTemplate: htmlTemplate,
       backgroundColor: widget.backgroundColor,
       src: '/model',
@@ -215,7 +215,6 @@ class _ModelViewerState extends State<ModelViewer> {
       enableColorChange: widget.enableColorChange,
       iosSrc: widget.iosSrc,
     );
-    return htmlBuild;
   }
 
   Future<void> _initProxy() async {


### PR DESCRIPTION
I added following callbacks:
```
  /// Invoked once when the model viewer is created.
  final VoidCallback onModelViewCreated;

  /// Invoked when the model viewer has finished loading the url.
  final VoidCallback onModelViewStarted;

  /// Invoked when the model viewer has finished loading the url.
  ///
  /// Please note: This function is invoked when the url has finished loading,
  /// but it doesn't represents the finished loading process of the model visibility.
  final VoidCallback onModelViewFinished;

  /// Invoked when the model viewer has loaded the model and the model is visibile.
  /// See: https://modelviewer.dev/docs/#entrydocs-loading-events-modelVisibility
  final VoidCallback onModelIsVisisble;

  /// Invoked when the model viewer has failed to load the resource.
  final ValueChanged<String> onModelViewError;
```